### PR TITLE
hotFix: ensembl gene id extraction from transcript sequence header

### DIFF
--- a/TranscriptSequence.cpp
+++ b/TranscriptSequence.cpp
@@ -61,7 +61,8 @@ bool TranscriptSequence::readSequence(string fileName, refFormatT format){//{{{
             pos=min(trDesc.find(" gene:"),trDesc.find("gene="));
             if(pos!=(long)string::npos){
                geneDesc.clear();
-               geneDesc.str(trDesc.substr(pos+6));
+               if(trDesc[pos] == ' ') pos++;
+               geneDesc.str(trDesc.substr(pos+5));
                geneDesc >> geneName;
                geneNames.push_back(geneName);
             }else{

--- a/TranscriptSequence.cpp
+++ b/TranscriptSequence.cpp
@@ -58,10 +58,10 @@ bool TranscriptSequence::readSequence(string fileName, refFormatT format){//{{{
                gotTrNames = false;
             }
          }else{ // format == STANDARD
-            pos=min(trDesc.find("gene:"),trDesc.find("gene="));
+            pos=min(trDesc.find(" gene:"),trDesc.find("gene="));
             if(pos!=(long)string::npos){
                geneDesc.clear();
-               geneDesc.str(trDesc.substr(pos+5));
+               geneDesc.str(trDesc.substr(pos+6));
                geneDesc >> geneName;
                geneNames.push_back(geneName);
             }else{


### PR DESCRIPTION
Apparently we are interested in ensemble gene ID rather than in "havana_ig_gene" attribute.

Here is an example annotation of fasta sequence from original transcript sequence file:
ENST00000390575 havana_ig_gene:known chromosome:GRCh38:14:105893542:105893561:-1 gene:ENSG00000211915 gene_biotype:IG_D_gene transcript_biotype:IG_D_gene